### PR TITLE
TNFW speedup and memory changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Test with pytest
         run: |
           cd paltax
-          coverage run --source paltax --omit="*Configs/*,*_test.py,main.py" -m unittest discover -v -p "*_test.py"
+          coverage run --source paltax --omit="**/Configs/**,*_test.py,main.py" -m unittest discover -v -p "*_test.py"
           coverage lcov
       - name: Coveralls
         uses: coverallsapp/github-action@master

--- a/paltax/InputConfigs/input_config_wdm.py
+++ b/paltax/InputConfigs/input_config_wdm.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Configuration file using only 50 percent of sources.
+"""Configuration file for warm dark matter.
 """
 
 from  paltax.InputConfigs import input_config_br
@@ -45,7 +45,7 @@ def get_config():
         'num_z_bins': 1000,
         'los_pad_length': 10,
         'subhalos_pad_length': 8192,
-        'subhalos_n_chunks': 32,
+        'subhalos_n_chunks': 16,
         'sampling_pad_length': 2000000,
     }
 

--- a/paltax/InputConfigs/input_config_wdm.py
+++ b/paltax/InputConfigs/input_config_wdm.py
@@ -44,7 +44,8 @@ def get_config():
     config['kwargs_simulation'] = {
         'num_z_bins': 1000,
         'los_pad_length': 10,
-        'subhalos_pad_length': 7500,
+        'subhalos_pad_length': 8192,
+        'subhalos_n_chunks': 32,
         'sampling_pad_length': 2000000,
     }
 

--- a/paltax/TrainConfigs/train_config_snpe_wdm.py
+++ b/paltax/TrainConfigs/train_config_snpe_wdm.py
@@ -23,14 +23,14 @@ def get_config():
     config.model = 'ResNet50'
 
     config.momentum = 0.9
-    config.batch_size = 8
+    config.batch_size = 64
 
     config.cache = False
     config.half_precision = False
 
     # Need to set the boundaries of how long the model will train generically
     # and when the sequential training will turn on.
-    config.steps_per_epoch = FieldReference(15_600) # Assuming 4 GPUs
+    config.steps_per_epoch = FieldReference(1_950) # Assuming 4 GPUs
     config.num_initial_train_steps = config.get_ref('steps_per_epoch') * 10
     config.num_steps_per_refinement = config.get_ref('steps_per_epoch') * 10
     config.num_train_steps = config.get_ref('steps_per_epoch') * 500

--- a/paltax/image_simulation_test.py
+++ b/paltax/image_simulation_test.py
@@ -558,12 +558,12 @@ class ImageSimulationTest(chex.TestCase, parameterized.TestCase):
             image_simulation._ray_shooting_group,
             all_lens_models=all_lens_models))
 
-        new_state, new_state_copy = ray_shooting_group(
-            state, kwargs_lens_slice, cosmology_params, z_source, z_lens)
+        new_state = ray_shooting_group(
+            state, kwargs_lens_slice, cosmology_params, z_source, z_lens
+        )
 
-        for si in range(len(new_state)):
-            np.testing.assert_allclose(new_state[si], expected_state[si],
-                                       rtol=1e-5)
+        for si, ns in enumerate(new_state):
+            np.testing.assert_allclose(ns, expected_state[si], rtol=1e-5)
 
     @chex.all_variants
     @parameterized.named_parameters([
@@ -599,11 +599,8 @@ class ImageSimulationTest(chex.TestCase, parameterized.TestCase):
             z_source,
         )
 
-        for si in range(len(new_state)):
-            np.testing.assert_allclose(new_state[si], expected[si],
-                                       rtol=1e-2)
-            np.testing.assert_allclose(new_state_copy[si], expected[si],
-                                       rtol=1e-2)
+        for si, ns in enumerate(new_state):
+            np.testing.assert_allclose(ns, expected[si], rtol=1e-2)
 
     @chex.all_variants
     def test__ray_step_add(self):

--- a/paltax/input_pipeline.py
+++ b/paltax/input_pipeline.py
@@ -807,6 +807,7 @@ def draw_image_and_truth(
     num_z_bins = kwargs_simulation['num_z_bins']
     los_pad_length = kwargs_simulation['los_pad_length']
     subhalos_pad_length = kwargs_simulation['subhalos_pad_length']
+    subhalos_n_chunks = kwargs_simulation.get('subhalos_n_chunks', 1)
     sampling_pad_length = kwargs_simulation['sampling_pad_length']
 
     # Draw an instance of the parameter values for each object in our lensing
@@ -888,7 +889,8 @@ def draw_image_and_truth(
     image_supersampled = image_simulation.generate_image(
         grid_x, grid_y, kwargs_lens_all, source_params,
         lens_light_params, kwargs_psf, cosmology_params, z_source,
-        kwargs_detector, all_models, lookup_tables
+        kwargs_detector, all_models, apply_psf=True,
+        lookup_tables=lookup_tables, subhalos_n_chunks=subhalos_n_chunks
     )
     image = utils.downsample(
         image_supersampled, kwargs_detector['supersampling_factor']

--- a/paltax/input_pipeline_test.py
+++ b/paltax/input_pipeline_test.py
@@ -942,6 +942,7 @@ class InputPipelineTests(chex.TestCase, parameterized.TestCase):
             'num_z_bins': 10,
             'los_pad_length': 10,
             'subhalos_pad_length': 10,
+            'subhalos_n_chunks': 2,
             'sampling_pad_length': 100,
         }
         kwargs_psf = {

--- a/paltax/input_pipeline_test.py
+++ b/paltax/input_pipeline_test.py
@@ -637,8 +637,22 @@ class InputPipelineTests(chex.TestCase, parameterized.TestCase):
         self.assertAlmostEqual(cosmology_params['r_max'], r_max, places=6)
 
         # Test that the cosmos images are present
-        self.assertTupleEqual(cosmology_params['cosmos_images'].shape,
-                              (2, 256, 256))
+        self.assertTupleEqual(
+            cosmology_params['cosmos_images'].shape, (2, 256, 256)
+        )
+
+    def test_initialize_lookup_tables(self):
+        # Test that the lookup tables are added for the provided models.
+        config = {
+            'all_models': {
+                'all_los_models': (lens_models.TNFW(),)
+            }
+        }
+        lookup_tables = input_pipeline.initialize_lookup_tables(config)
+
+        self.assertTrue('tnfw_lookup_dr' in lookup_tables)
+        self.assertTrue('tnfw_lookup_log_min_radius' in lookup_tables)
+        self.assertTrue('tnfw_lookup_nfw_func' in lookup_tables)
 
     @chex.all_variants(without_device=False)
     def test_draw_sample(self):
@@ -911,8 +925,10 @@ class InputPipelineTests(chex.TestCase, parameterized.TestCase):
         normalize_config['main_deflector_params']['theta_e'] = (
             input_pipeline.encode_uniform(minimum=1.0, maximum=1.2))
 
-        cosmology_params = input_pipeline.initialize_cosmology_params(config,
-                                                                     rng)
+        cosmology_params = input_pipeline.initialize_cosmology_params(
+            config, rng
+        )
+        lookup_tables = input_pipeline.initialize_lookup_tables(config)
         n_x = 4
         n_y = 4
         config['kwargs_detector'] = {
@@ -947,11 +963,13 @@ class InputPipelineTests(chex.TestCase, parameterized.TestCase):
             kwargs_simulation=kwargs_simulation,
             kwargs_detector=config['kwargs_detector'],
             kwargs_psf=kwargs_psf, truth_parameters=truth_parameters,
-            normalize_config=normalize_config))
+            normalize_config=normalize_config,
+            lookup_tables=lookup_tables))
         rotation_angle = 0.0
-        image, truth = draw_image_and_truth(config['lensing_config'],
-                                            cosmology_params, grid_x, grid_y,
-                                            rng, rotation_angle)
+        image, truth = draw_image_and_truth(
+            config['lensing_config'], cosmology_params, grid_x, grid_y, rng,
+            rotation_angle
+        )
 
         # Just test that the data and truths vary and that they are normalized
         # as expected.

--- a/paltax/lens_models.py
+++ b/paltax/lens_models.py
@@ -17,8 +17,9 @@ Implementation of mass profiles for lensing closely following implementations
 in lenstronomy: https://github.com/lenstronomy/lenstronomy.
 """
 
-from typing import Dict, Mapping, Tuple, Union
+from typing import Dict, Mapping, Optional, Tuple, Union
 
+import jax
 import jax.numpy as jnp
 
 from paltax import utils
@@ -74,6 +75,22 @@ class _LensModelBase():
         return all_kwargs
 
 
+    @staticmethod
+    def add_lookup_tables(
+        lookup_tables: Dict[str, jnp.ndarray]
+    ) ->  Dict[str, jnp.ndarray]:
+        """Add lookup tables used for derivative calculations.
+
+        Args:
+            lookup_tables: Potentially empty dictionary of current lookup
+                tables. Will be modified.
+
+        Return:
+            Modified lookup tables.
+        """
+        return lookup_tables
+
+
 class EPL(_LensModelBase):
     """Elliptical Power Law mass profile.
 
@@ -89,7 +106,8 @@ class EPL(_LensModelBase):
     @staticmethod
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, theta_e: float, slope: float,
-        axis_ratio: float, angle: float, center_x: float, center_y: float
+        axis_ratio: float, angle: float, center_x: float, center_y: float,
+        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Calculate the derivative of the potential for the EPL mass profile.
 
@@ -102,6 +120,7 @@ class EPL(_LensModelBase):
             angle: Clockwise angle of orientation of major axis.
             center_x: X-coordinate center of the EPL profile.
             center_y: Y-coordinate cetner of the EPL profile.
+            lookup_tables: Optional lookup tables initialized with class.
 
         Returns:
             X- and y-component of the derivatives.
@@ -182,7 +201,8 @@ class EPLEllip(_LensModelBase):
     @staticmethod
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, theta_e: float, slope: float,
-        ellip_x: float, ellip_xy: float, center_x: float, center_y: float
+        ellip_x: float, ellip_xy: float, center_x: float, center_y: float,
+        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Calculate the derivative of the potential for the EPL mass profile.
 
@@ -195,6 +215,7 @@ class EPLEllip(_LensModelBase):
             ellip_xy: XY-componenet of the ellipticity.
             center_x: X-coordinate center of the EPL profile.
             center_y: Y-coordinate cetner of the EPL profile.
+            lookup_tables: Optional lookup tables initialized with class.
 
         Returns:
             X- and y-component of the derivatives.
@@ -217,7 +238,8 @@ class NFW(_LensModelBase):
     @staticmethod
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, scale_radius: float, alpha_rs: float,
-        center_x: float, center_y: float
+        center_x: float, center_y: float,
+        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the NFW profile derivatives.
 
@@ -228,6 +250,7 @@ class NFW(_LensModelBase):
             alpha_rs: Derivative at the scale radius
             center_x: X-coordinate center of the NFW profile.
             center_y: Y-coordinate cetner of the NFW profile.
+            lookup_tables: Optional lookup tables initialized with class.
 
         Returns:
             X- and y-component of the derivative.
@@ -256,7 +279,8 @@ class NFW(_LensModelBase):
     @staticmethod
     def _nfw_derivatives(
         radius: jnp.ndarray, scale_radius: float, rho_input: float,
-        x_centered: jnp.ndarray, y_centered: jnp.ndarray
+        x_centered: jnp.ndarray, y_centered: jnp.ndarray,
+        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the NFW profile derivatives.
 
@@ -266,6 +290,7 @@ class NFW(_LensModelBase):
             rho_input: Normalization of the NFW profile.
             x_centered: X-coordinate offset from NFW center.
             y_centered: Y-coordinate offset from NFW center.
+            lookup_tables: Optional lookup tables initialized with class.
 
         Returns:
             X- and y-component of the derivative.
@@ -319,7 +344,8 @@ class ShearCart(_LensModelBase):
     @staticmethod
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, gamma_one: float, gamma_two: float,
-        zero_x: float, zero_y: float
+        zero_x: float, zero_y: float,
+        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the shear profile derivatives.
 
@@ -330,6 +356,7 @@ class ShearCart(_LensModelBase):
             gamma_two: Off-diagonal component of shear.
             zero_x: X-coordinate where shear is 0.
             zero_y: Y-coordinate where shear is 0.
+            lookup_tables: Optional lookup tables initialized with class.
 
         Returns:
             X- and y-component of the derivative.
@@ -352,7 +379,8 @@ class Shear(_LensModelBase):
     @staticmethod
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, gamma_ext: float, angle: float,
-        zero_x: float, zero_y: float
+        zero_x: float, zero_y: float,
+        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the shear profile derivatives.
 
@@ -364,6 +392,7 @@ class Shear(_LensModelBase):
                 simulation grid.
             zero_x: X-coordinate where shear is 0.
             zero_y: Y-coordinate where shear is 0.
+            lookup_tables: Optional lookup tables initialized with class.
 
         Returns:
             X- and y-component of the derivative.
@@ -402,7 +431,8 @@ class TNFW(NFW):
     @staticmethod
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, scale_radius: float, alpha_rs: float,
-        trunc_radius: float, center_x: float, center_y: float
+        trunc_radius: float, center_x: float, center_y: float,
+        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the TNFW profile derivatives.
 
@@ -414,6 +444,7 @@ class TNFW(NFW):
             trunc_radius: Truncation radius for TNFW profile.
             center_x: X-coordinate center of the TNFW profile.
             center_y: Y-coordinate cetner of the TNFW profile.
+            lookup_tables: Optional lookup tables initialized with class.
 
         Returns:
             X- and y-component of the derivative.
@@ -422,13 +453,16 @@ class TNFW(NFW):
         x_centered = x - center_x
         y_centered = y - center_y
         radius = jnp.sqrt(x_centered**2 + y_centered**2)
-        return TNFW._tnfw_derivatives(radius, scale_radius, rho_input,
-                                      trunc_radius, x_centered, y_centered)
+        return TNFW._tnfw_derivatives(
+            radius, scale_radius, rho_input, trunc_radius, x_centered,
+            y_centered, lookup_tables
+        )
 
     @staticmethod
     def _tnfw_derivatives(
         radius: jnp.ndarray, scale_radius: float, rho_input: float,
-        trunc_radius: float, x_centered: jnp.ndarray, y_centered: jnp.ndarray
+        trunc_radius: float, x_centered: jnp.ndarray, y_centered: jnp.ndarray,
+        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the TNFW profile derivatives.
 
@@ -439,14 +473,16 @@ class TNFW(NFW):
             trunc_radius: Truncation radius for TNFW profile.
             x_centered: X-coordinate offset from TNFW center.
             y_centered: Y-coordinate offset from TNFW center.
+            lookup_tables: Optional lookup tables initialized with class.
 
         Returns:
             X- and y-component of the derivative.
         """
         reduced_radius = radius / scale_radius
         reduced_trunc_radius = trunc_radius / scale_radius
-        tnfw_integral = TNFW._tnfw_integral(reduced_radius,
-                                            reduced_trunc_radius)
+        tnfw_integral = TNFW._tnfw_integral(
+            reduced_radius, reduced_trunc_radius, lookup_tables
+        )
         derivative_norm = 4. * rho_input * scale_radius * tnfw_integral
         derivative_norm /= reduced_radius**2
 
@@ -454,20 +490,23 @@ class TNFW(NFW):
 
     @staticmethod
     def _tnfw_integral(
-        reduced_radius: jnp.ndarray, reduced_trunc_radius: float
+        reduced_radius: jnp.ndarray, reduced_trunc_radius: float,
+        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
     ) -> jnp.ndarray:
         """Return analytic solution to integral of TNFW profile.
 
         Args:
             reduced_radius: Upper limits for integrals in reduced units.
             reduced_trunc_radius: Reduced truncation radius for TNFW profile.
+            lookup_tables: Optional lookup tables initialized with class.
 
         Returns:
             Solution to integral for each provided upper limit.
         """
-        solution = (reduced_trunc_radius**2 + 1 + 2 *
-                    (reduced_radius**2 - 1))
-        solution *= TNFW._nfw_function(reduced_radius)
+        solution = (
+            reduced_trunc_radius ** 2 + 1 + 2 * (reduced_radius ** 2 - 1)
+        )
+        solution *= TNFW._nfw_function(reduced_radius, lookup_tables)
         solution += reduced_trunc_radius * jnp.pi + (
                 reduced_trunc_radius**2 - 1) * jnp.log(reduced_trunc_radius)
         solution += jnp.sqrt(reduced_trunc_radius**2 + reduced_radius**2) * (
@@ -478,7 +517,7 @@ class TNFW(NFW):
 
     @staticmethod
     def _tnfw_log(
-        reduced_radius: jnp.ndarray, reduced_trunc_radius: float
+        reduced_radius: jnp.ndarray, reduced_trunc_radius: float,
     ) -> jnp.ndarray:
         """Evaluate log expression that appears in the TNFW calculations.
 
@@ -489,21 +528,51 @@ class TNFW(NFW):
         Returns:
             Log calculation output.
         """
-        return jnp.log(reduced_radius * (reduced_trunc_radius +
-                                         jnp.sqrt(reduced_radius**2 +
-                                                  reduced_trunc_radius**2))**-1)
+        return jnp.log(
+            reduced_radius * (
+                reduced_trunc_radius +
+                jnp.sqrt(reduced_radius**2 + reduced_trunc_radius**2)
+            ) ** -1
+        )
 
     @staticmethod
-    def _nfw_function(reduced_radius: jnp.ndarray) -> jnp.ndarray:
+    def _nfw_function(
+        reduced_radius: jnp.ndarray,
+        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
+    ) -> jnp.ndarray:
         """Evaluate NFW function.
 
         Args:
             reduced_radius: Upper limits for integrals in reduced units.
+            lookup_tables: Optional lookup tables initialized with class.
 
         Returns:
             NFW function output.
         """
         nfw_function = jnp.zeros_like(reduced_radius)
+
+        # Use the lookup table if it is provided.
+        if lookup_tables and 'tnfw_lookup_nfw_func' in lookup_tables:
+
+            # Conduct a linear interpolation between the static lookup table
+            # values.
+            tnfw_dr = lookup_tables['tnfw_lookup_dr']
+            log_min_radius = lookup_tables['tnfw_lookup_log_min_radius']
+            lookup_values = lookup_tables['tnfw_lookup_nfw_func']
+
+            unrounded_i = (jnp.log10(reduced_radius) - log_min_radius) / tnfw_dr
+
+            lookup_i_upper = jax.lax.min(
+                jnp.ceil(unrounded_i).astype(int), len(lookup_values) - 1
+            )
+            lookup_i_lower = jax.lax.max(jnp.floor(unrounded_i).astype(int), 0)
+            frac_i = unrounded_i % 1
+
+            # Interpolation using the lookup table.
+            interpolated = (1 - frac_i) * lookup_values[lookup_i_lower]
+            interpolated += (frac_i) * lookup_values[lookup_i_upper]
+
+            return interpolated
 
         # There are three regimes for the NFW function, which we will calculate
         # with masks to avoid indexing.
@@ -519,3 +588,28 @@ class TNFW(NFW):
             jnp.arctan((reduced_radius**2 - 1)**.5)) * is_above_one
 
         return nfw_function
+
+    @staticmethod
+    def add_lookup_tables(
+        lookup_tables: Dict[str, jnp.ndarray]
+    ) ->  Dict[str, jnp.ndarray]:
+        """Add lookup tables used for derivative calculations.
+
+        Args:
+            lookup_tables: Potentially empty dictionary of current lookup
+                tables. Will be modified.
+
+        Return:
+            Modified lookup tables.
+        """
+        # Add the lookup table for the exact nfw integral calculation.
+        log_r_min = -3
+        log_r_max = 1
+        n_dr = 4001
+        lookup_tables['tnfw_lookup_dr'] = (log_r_max - log_r_min) / (n_dr - 1)
+        lookup_tables['tnfw_lookup_log_min_radius'] = log_r_min
+        lookup_tables['tnfw_lookup_nfw_func'] = TNFW._nfw_function(
+            jnp.logspace(log_r_min, log_r_max, n_dr)
+        )
+
+        return lookup_tables

--- a/paltax/lens_models.py
+++ b/paltax/lens_models.py
@@ -74,10 +74,9 @@ class _LensModelBase():
         _ = cosmology_params
         return all_kwargs
 
-
     @staticmethod
     def add_lookup_tables(
-        lookup_tables: Dict[str, jnp.ndarray]
+        lookup_tables: Dict[str, Union[float, jnp.ndarray]]
     ) ->  Dict[str, jnp.ndarray]:
         """Add lookup tables used for derivative calculations.
 
@@ -107,7 +106,7 @@ class EPL(_LensModelBase):
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, theta_e: float, slope: float,
         axis_ratio: float, angle: float, center_x: float, center_y: float,
-        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Calculate the derivative of the potential for the EPL mass profile.
 
@@ -202,7 +201,7 @@ class EPLEllip(_LensModelBase):
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, theta_e: float, slope: float,
         ellip_x: float, ellip_xy: float, center_x: float, center_y: float,
-        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Calculate the derivative of the potential for the EPL mass profile.
 
@@ -239,7 +238,7 @@ class NFW(_LensModelBase):
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, scale_radius: float, alpha_rs: float,
         center_x: float, center_y: float,
-        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the NFW profile derivatives.
 
@@ -280,7 +279,7 @@ class NFW(_LensModelBase):
     def _nfw_derivatives(
         radius: jnp.ndarray, scale_radius: float, rho_input: float,
         x_centered: jnp.ndarray, y_centered: jnp.ndarray,
-        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the NFW profile derivatives.
 
@@ -345,7 +344,7 @@ class ShearCart(_LensModelBase):
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, gamma_one: float, gamma_two: float,
         zero_x: float, zero_y: float,
-        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the shear profile derivatives.
 
@@ -380,7 +379,7 @@ class Shear(_LensModelBase):
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, gamma_ext: float, angle: float,
         zero_x: float, zero_y: float,
-        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the shear profile derivatives.
 
@@ -432,7 +431,7 @@ class TNFW(NFW):
     def derivatives(
         x: jnp.ndarray, y: jnp.ndarray, scale_radius: float, alpha_rs: float,
         trunc_radius: float, center_x: float, center_y: float,
-        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the TNFW profile derivatives.
 
@@ -462,7 +461,7 @@ class TNFW(NFW):
     def _tnfw_derivatives(
         radius: jnp.ndarray, scale_radius: float, rho_input: float,
         trunc_radius: float, x_centered: jnp.ndarray, y_centered: jnp.ndarray,
-        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]] = None
     ) -> Tuple[jnp.ndarray, jnp.ndarray]:
         """Return the TNFW profile derivatives.
 
@@ -491,7 +490,7 @@ class TNFW(NFW):
     @staticmethod
     def _tnfw_integral(
         reduced_radius: jnp.ndarray, reduced_trunc_radius: float,
-        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]] = None
     ) -> jnp.ndarray:
         """Return analytic solution to integral of TNFW profile.
 
@@ -538,7 +537,7 @@ class TNFW(NFW):
     @staticmethod
     def _nfw_function(
         reduced_radius: jnp.ndarray,
-        lookup_tables: Optional[Dict[str, jnp.ndarray]] = None
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]] = None
     ) -> jnp.ndarray:
         """Evaluate NFW function.
 
@@ -591,7 +590,7 @@ class TNFW(NFW):
 
     @staticmethod
     def add_lookup_tables(
-        lookup_tables: Dict[str, jnp.ndarray]
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]]
     ) ->  Dict[str, jnp.ndarray]:
         """Add lookup tables used for derivative calculations.
 

--- a/paltax/lens_models_test.py
+++ b/paltax/lens_models_test.py
@@ -100,8 +100,8 @@ def _prepare__polar_to_cartesian_expected(gamma_ext, angle):
         return jnp.array([19.4777074, 5.719170904])
     else:
         raise ValueError(
-                f'gamma_ext={gamma_ext} angle={angle} are not a supported parameter'
-                ' combination.')
+                f'gamma_ext={gamma_ext} angle={angle} are not a supported '
+                ' parameter combination.')
 
 
 class AllTest(chex.TestCase):
@@ -119,7 +119,7 @@ class AllTest(chex.TestCase):
 
 
 class LensModelBaseTest(chex.TestCase):
-    """Runs tests of __SourceModelBase functions."""
+    """Runs tests of __LensModelBase functions."""
 
     def test_modify_cosmology_params(self):
         # Make sure the dict is modified by default.
@@ -145,6 +145,14 @@ class LensModelBaseTest(chex.TestCase):
 
         self.assertDictEqual(
             input_dict, convert_to_angular(input_dict, cosmology_params))
+
+    def test_add_lookup_tables(self):
+        # Test that the dictionary isn't modified.
+        lookup_tables = {}
+        lookup_tables = lens_models._LensModelBase.add_lookup_tables(
+            lookup_tables
+        )
+        self.assertEmpty(lookup_tables)
 
 
 class EPLTest(chex.TestCase, parameterized.TestCase):
@@ -188,7 +196,8 @@ class EPLTest(chex.TestCase, parameterized.TestCase):
 
     @chex.all_variants
     def test__hypergeometric_series(self):
-        ellip_angle = jax.random.normal(jax.random.PRNGKey(0), shape=(3,)) * np.pi
+        ellip_angle = jax.random.normal(jax.random.PRNGKey(0), shape=(3,))
+        ellip_angle *= np.pi
         parameters = _prepare_epl_parameters()
         expected = jnp.array([
                 0.83773771 - 0.4450688j,
@@ -196,11 +205,16 @@ class EPLTest(chex.TestCase, parameterized.TestCase):
                 0.60248699 + 0.86020766j,
         ])
 
-        hypergeometric_series = self.variant(lens_models.EPL._hypergeometric_series)
+        hypergeometric_series = self.variant(
+            lens_models.EPL._hypergeometric_series
+        )
 
         np.testing.assert_allclose(
-                hypergeometric_series(ellip_angle, parameters['slope'],
-                                                            parameters['axis_ratio']), expected)
+            hypergeometric_series(
+                ellip_angle, parameters['slope'],
+                parameters['axis_ratio']
+            ), expected
+        )
 
 
 class EPLEllipTest(chex.TestCase):
@@ -248,12 +262,15 @@ class NFWTest(chex.TestCase, parameterized.TestCase):
         derivatives = self.variant(lens_models.NFW.derivatives)
 
         np.testing.assert_allclose(
-                jnp.array(derivatives(x, y, **nfw_parameters)), expected, rtol=1e-4)
+            jnp.array(derivatives(x, y, **nfw_parameters)), expected, rtol=1e-4
+        )
 
     @chex.all_variants
     @parameterized.named_parameters([
-            (f'_ars_{ars}_sr_{sr}', ars, sr, expected) for ars, sr, expected in zip(
-                    [0.5, 1.2], [0.1, 1.5], [40.736141915886606, 0.43451884710279054])
+            (f'_ars_{ars}_sr_{sr}', ars, sr, expected)
+                for ars, sr, expected in zip(
+                    [0.5, 1.2], [0.1, 1.5],
+                    [40.736141915886606, 0.43451884710279054])
     ])
     def test__alpha_to_rho(self, ars, sr, expected):
         self.assertAlmostEqual(
@@ -265,17 +282,18 @@ class NFWTest(chex.TestCase, parameterized.TestCase):
         radius = jnp.sqrt(x**2 + y**2)
         rho_input = 2.0
         nfw_parameters = _prepare_nfw_parameters()
-        expected = jnp.array([[0.42659888, 1.3704396, -2.2209157],
-                                                    [3.4939308, -3.2851558, -2.4732482]])
+        expected = jnp.array(
+            [[0.42659888, 1.3704396, -2.2209157],
+            [3.4939308, -3.2851558, -2.4732482]]
+        )
 
         nfw_derivatives = self.variant(lens_models.NFW._nfw_derivatives)
 
         np.testing.assert_allclose(
-                jnp.array(
-                        nfw_derivatives(radius, nfw_parameters['scale_radius'], rho_input,
-                                                        x, y)),
-                expected,
-                rtol=1e-4)
+            jnp.array(nfw_derivatives(
+                radius, nfw_parameters['scale_radius'], rho_input, x, y
+            )), expected, rtol=1e-4
+        )
 
     @chex.all_variants
     def test__nfw_integral(self):
@@ -336,13 +354,17 @@ class TNFWTest(chex.TestCase, parameterized.TestCase):
     def test_derivatives(self):
         x, y = _prepare_x_y()
         tnfw_parameters = _prepare_tnfw_parameters()
-        expected = jnp.array([[-0.13036814, 0.8646701, -2.6658154],
-                                                    [2.8560917, -2.8538284, -1.4275427]])
+        expected = jnp.array(
+            [[-0.13036814, 0.8646701, -2.6658154],
+            [2.8560917, -2.8538284, -1.4275427]]
+        )
 
         derivatives = self.variant(lens_models.TNFW.derivatives)
 
         np.testing.assert_allclose(
-                jnp.asarray(derivatives(x, y, **tnfw_parameters)), expected, rtol=1e-5)
+            jnp.asarray(derivatives(x, y, **tnfw_parameters)), expected,
+            rtol=1e-5
+        )
 
     @chex.all_variants
     def test__tnfw_derivatives(self):
@@ -350,17 +372,19 @@ class TNFWTest(chex.TestCase, parameterized.TestCase):
         r = jnp.sqrt(x**2 + y**2)
         tnfw_parameters = _prepare_tnfw_parameters()
         rho_input = 2.0
-        expected = jnp.array([[0.3161475, 0.97571015, -1.7840269],
-                                                    [2.5893118, -2.3389282, -1.9868112]])
+        expected = jnp.array(
+            [[0.3161475, 0.97571015, -1.7840269],
+            [2.5893118, -2.3389282, -1.9868112]]
+        )
 
         tnfw_derivatives = self.variant(lens_models.TNFW._tnfw_derivatives)
 
         np.testing.assert_allclose(
-                jnp.asarray(
-                        tnfw_derivatives(r, tnfw_parameters['scale_radius'], rho_input,
-                                                         tnfw_parameters['trunc_radius'], x, y)),
-                expected,
-                rtol=1e-5)
+            jnp.asarray(
+                tnfw_derivatives(r, tnfw_parameters['scale_radius'], rho_input,
+                tnfw_parameters['trunc_radius'], x, y)
+            ), expected, rtol=1e-5
+        )
 
     @chex.all_variants
     def test__tnfw_integral(self):
@@ -382,7 +406,9 @@ class TNFWTest(chex.TestCase, parameterized.TestCase):
         tnfw_log = self.variant(lens_models.TNFW._tnfw_log)
 
         np.testing.assert_allclose(
-                tnfw_log(reduced_radius, truncated_reduced_radius), expected, rtol=1e-5)
+            tnfw_log(reduced_radius, truncated_reduced_radius), expected,
+            rtol=1e-5
+        )
 
     @chex.all_variants
     def test__nfw_function(self):
@@ -394,3 +420,34 @@ class TNFWTest(chex.TestCase, parameterized.TestCase):
         np.testing.assert_allclose(
                 nfw_function(reduced_radius), expected, rtol=1e-5)
 
+    def test_add_lookup_tables(self):
+        # Check that the lookup table adds the desired nfw_function lookup.
+        lookup_tables = {}
+        lookup_tables = lens_models.TNFW.add_lookup_tables(lookup_tables)
+
+        self.assertAlmostEqual(lookup_tables['tnfw_lookup_dr'], 0.001)
+        self.assertAlmostEqual(lookup_tables['tnfw_lookup_log_min_radius'], -3)
+        np.testing.assert_array_almost_equal(
+            lookup_tables['tnfw_lookup_nfw_func'],
+            lens_models.TNFW._nfw_function(jnp.logspace(-3, 1, 4001))
+        )
+
+    @chex.all_variants
+    def test_derivatives_lookup(self):
+        # Test that the derivatives return the same answer with and without
+        # the use of the lookup tables.
+        x, y = _prepare_x_y()
+        tnfw_parameters = _prepare_tnfw_parameters()
+
+        lookup_tables = lens_models.TNFW.add_lookup_tables({})
+        derivatives_lookup = self.variant(
+            functools.partial(
+                lens_models.TNFW.derivatives, lookup_tables=lookup_tables
+            )
+        )
+
+        np.testing.assert_allclose(
+            jnp.asarray(derivatives_lookup(x, y, **tnfw_parameters)),
+            jnp.asarray(lens_models.TNFW.derivatives(x, y, **tnfw_parameters)),
+            rtol=1e-5
+        )

--- a/paltax/lens_models_test.py
+++ b/paltax/lens_models_test.py
@@ -445,9 +445,20 @@ class TNFWTest(chex.TestCase, parameterized.TestCase):
                 lens_models.TNFW.derivatives, lookup_tables=lookup_tables
             )
         )
-
         np.testing.assert_allclose(
             jnp.asarray(derivatives_lookup(x, y, **tnfw_parameters)),
             jnp.asarray(lens_models.TNFW.derivatives(x, y, **tnfw_parameters)),
             rtol=1e-5
+        )
+
+        # Test that the lookup tables are being used.
+        lookup_tables['tnfw_lookup_nfw_func'] = jnp.ones(5) * 10
+        derivatives_lookup = self.variant(
+            functools.partial(
+                lens_models.TNFW.derivatives, lookup_tables=lookup_tables
+            )
+        )
+        np.testing.assert_array_less(
+            jnp.abs(lens_models.TNFW.derivatives(x, y, **tnfw_parameters)[0]),
+            jnp.abs(derivatives_lookup(x, y, **tnfw_parameters)[0])
         )

--- a/paltax/psf_models.py
+++ b/paltax/psf_models.py
@@ -53,6 +53,21 @@ class _PSFModelBase():
         """
         return cosmology_params
 
+    @staticmethod
+    def add_lookup_tables(
+        lookup_tables: Dict[str, Union[float, jnp.ndarray]]
+    ) ->  Dict[str, jnp.ndarray]:
+        """Add lookup tables used for psf calculations.
+
+        Args:
+            lookup_tables: Potentially empty dictionary of current lookup
+                tables. Will be modified.
+
+        Return:
+            Modified lookup tables.
+        """
+        return lookup_tables
+
 
 class Gaussian(_PSFModelBase):
     """Implementation of Gaussian point spread function."""

--- a/paltax/psf_models_test.py
+++ b/paltax/psf_models_test.py
@@ -75,6 +75,14 @@ class PSFModelBaseTest(chex.TestCase):
                 input_dict)
         self.assertDictEqual(input_dict, new_dict)
 
+    def test_add_lookup_tables(self):
+        # Test that the dictionary isn't modified.
+        lookup_tables = {}
+        lookup_tables = psf_models._PSFModelBase.add_lookup_tables(
+            lookup_tables
+        )
+        self.assertEmpty(lookup_tables)
+
 
 class GaussianTest(chex.TestCase):
     """Runs tests of Gaussian derivative functions."""

--- a/paltax/source_models_test.py
+++ b/paltax/source_models_test.py
@@ -176,6 +176,14 @@ class SourceModelBaseTest(chex.TestCase):
         self.assertDictEqual(
             input_dict, convert_to_angular(input_dict, cosmology_params))
 
+    def test_add_lookup_tables(self):
+        # Test that the dictionary isn't modified.
+        lookup_tables = {}
+        lookup_tables = source_models._SourceModelBase.add_lookup_tables(
+            lookup_tables
+        )
+        self.assertEmpty(lookup_tables)
+
 
 class InterpolTest(chex.TestCase, parameterized.TestCase):
     """Runs tests of Interpol brightness functions."""

--- a/paltax/utils.py
+++ b/paltax/utils.py
@@ -14,7 +14,7 @@
 """Strong lensing utility functions."""
 
 import functools
-from typing import Any, Protocol, Sequence, Tuple
+from typing import Any, Dict, Optional, Protocol, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -57,6 +57,7 @@ def coordinates_evaluate(
 def unpack_parameters_xy(
         func: Callback,
         parameters:Sequence[str],
+        lookup_tables: Optional[Dict[str, Union[float, jnp.ndarray]]] = None
 ) -> Callback:
     """Returns function wrapper that unpacks parameters for grid functions.
 
@@ -75,7 +76,9 @@ def unpack_parameters_xy(
     """
 
     def derivative_wrapper(x, y, kwargs, parameters):
-        return func(x, y, *[kwargs[param] for param in parameters])
+        return func(
+            x, y, *[kwargs[param] for param in parameters], lookup_tables
+        )
 
     return functools.partial(derivative_wrapper, parameters=parameters)
 


### PR DESCRIPTION
TNFW (and all lens and source profiles) now allows for lookup tables, leading to a 2x speedup in the simulations. Also now allows subhalos to be chunked before the vmap operation, allowing for larger batch sizes and removing previous memory limitations.